### PR TITLE
Rename Course Tool to CMU Courses, remove beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ CMU Courses (AKA ScottyLabs Course Tool) is a web application designed to aid st
 browsing courses, including information about course evaluations and schedules. It is actively maintained
 by [ScottyLabs](https://scottylabs.org).
 
-This is the second version of the Course Tool. The old version is currently deployed at [cmucourses.com](cmucourses.com)
-. The second version is a rewrite of the frontend and backend, with the inclusion of new features (currently a
-work-in-progress) such as:
+This is the second iteration of the Course Tool. The second version is a rewrite of the frontend and backend, with the
+inclusion of new features (currently a work-in-progress) such as:
 
 - Search
 - Filters

--- a/README.md
+++ b/README.md
@@ -1,53 +1,73 @@
-# ScottyLabs Course Tool
+# CMU Courses
 
-The ScottyLabs Course Tool is a web application designed to aid students at Carnegie Mellon University (CMU) to browse courses, including information about course evaluations and schedules. It is actively maintained by [ScottyLabs](https://scottylabs.org).
+CMU Courses (AKA ScottyLabs Course Tool) is a web application designed to aid students at Carnegie Mellon University in
+browsing courses, including information about course evaluations and schedules. It is actively maintained
+by [ScottyLabs](https://scottylabs.org).
 
-This is the second version of the Course Tool. The old version is currently deployed at [cmucourses.com](cmucourses.com). The second version is a rewrite of the frontend and backend, with the inclusion of new features (currently a work-in-progress) such as:
+This is the second version of the Course Tool. The old version is currently deployed at [cmucourses.com](cmucourses.com)
+. The second version is a rewrite of the frontend and backend, with the inclusion of new features (currently a
+work-in-progress) such as:
+
 - Search
 - Filters
 - Professor Search
 - Schedule Creation
 
-This new version is currently deployed at [beta.cmucourses.com](beta.cmucourses.com). This project is currently undergoing development, so expect large changes to the codebase and features to be unstable.
+This new version is currently deployed at [cmucourses.com](https://cmucourses.com). This project is currently undergoing
+development, so expect large changes to the codebase and features to be unstable.
 
 ## Getting Started
+
 To get started, run `npm install` in both the `frontend` and `backend` folders.
 
-Also, we use [Doppler](https://www.doppler.com) to populate the environment with the necessary secrets to access the database. Follow the instructions [here](https://docs.doppler.com/docs/install-cli) to install the Doppler CLI. Run `doppler setup` in the parent folder to set this up.
+Also, we use [Doppler](https://www.doppler.com) to populate the environment with the necessary secrets to access the
+database. Follow the instructions [here](https://docs.doppler.com/docs/install-cli) to install the Doppler CLI.
+Run `doppler setup` in the parent folder to set this up.
 
 ### Frontend
+
 To run the frontend in development mode:
+
 ```shell
 cd frontend
 npm run dev
 ```
+
 This runs the frontend at `http://localhost:3010`. It also watches for changes and reloads when a file is saved.
 
 To build and deploy the frontend, instead run:
+
 ```shell
 npm run build
 npm run start
 ```
 
 ### Backend
+
 To run the backend in development mode:
+
 ```shell
 cd backend
 npm run dev
 ```
+
 The backend should now be serving requests at `http://localhost:3000`.
 
 To deploy the backend, run
+
 ```shell
 npm run start
 ```
 
 ### Scrapers
-More information about the scrapers used to collect the data may be found at [this repo](https://github.com/ScottyLabs/course-scraper/).
+
+More information about the scrapers used to collect the data may be found
+at [this repo](https://github.com/ScottyLabs/course-scraper/).
 
 ## Technologies
 
 The Course Tool is built with several technologies.
+
 - The frontend is built using NextJS and React, Redux, Typescript and TailwindCSS.
 - The backend uses Express, MongoDB and JS.
 - The scrapers are written in JS.

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -162,9 +162,7 @@ export default function Header(): ReactElement {
               height={30}
               alt="favicon"
             />
-            <span className="ml-2">
-              CMU Courses <sup>β</sup>
-            </span>
+            <span className="ml-2">CMU Courses</span>
           </div>
         </Link>
       </div>

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -50,12 +50,12 @@ export const LoginModal = () => {
                     as="h3"
                     className="text-gray-900 text-lg font-medium leading-6"
                   >
-                    ScottyLabs Course Tool Beta
+                    CMU Courses
                   </Dialog.Title>
                   <div className="mt-1">
                     <p className="text-gray-400 text-sm">
-                      This is in beta, so expect things to break and change.
-                      Find out more about ScottyLabs{" "}
+                      CMU Courses is built and maintained by ScottyLabs. Find
+                      out more about us{" "}
                       <Link href={"https://www.scottylabs.org"}>here</Link>.
                       Your feedback is appreciated.
                     </p>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -12,7 +12,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <title>ScottyLabs Course Tool Beta</title>
+        <title>CMU Courses</title>
       </Head>
       <Provider store={store}>
         <PersistGate loading={null} persistor={persistor}>


### PR DESCRIPTION
# Description

Now that `cmucourses.com` points to this version of the Course Tool, it's time to remove the beta sign and rename this to CMU Courses.

# How Has This Been Tested?

Ran locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
