### PR TITLE
Match courses in schedule search without dashes

### DIFF
--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -49,6 +49,7 @@ const CourseCombobox = ({
     return allCourses.filter(
       (course) =>
         (course.courseID.includes(inputValue) ||
+          course.courseID.replaceAll('-', '').includes(inputValue) ||
           course.name.toLowerCase().includes(inputValue)) &&
         selectedItems.map(({ courseID }) => courseID).indexOf(course.courseID) <
           0


### PR DESCRIPTION
# Description

For Bootcamp: changed one line in ScheduleSearch.tsx

Closes #48

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Modifies filtering for courses in Schedule Explorer to match course codes without dashes

# How Has This Been Tested?

- [ ] Tested the feature in localhost by searching course codes with and without dashes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
