### PR TITLE
Added 'No FCEs Available' message where applicable

### DIFF
--- a/frontend/src/components/CourseCard.tsx
+++ b/frontend/src/components/CourseCard.tsx
@@ -106,7 +106,7 @@ const CourseCard = ({ info, showFCEs, showCourseInfo }: Props) => {
           </div>
         )}
       </div>
-      {showFCEs && fces && <FCEDetail fces={fces} />}
+      {showFCEs && <FCEDetail fces={fces} />}
     </Card>
   );
 };

--- a/frontend/src/components/FCETable.tsx
+++ b/frontend/src/components/FCETable.tsx
@@ -15,6 +15,7 @@ import { FCE } from "../app/types";
 import { sessionToString } from "../app/utils";
 import { StarRating } from "./StarRating";
 import Link from "./Link";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 
 const columns: ColumnDef<FCEDetailRow>[] = [
   {
@@ -141,7 +142,20 @@ export const FCETable = ({
   }
 
   if (!fces || aggregateData.fcesCounted == 0) {
-    return <></>;
+    return (
+      <div className="group flex flex-row items-center mt-2">
+      <div className="flex">
+        <ExclamationTriangleIcon
+          className={`h-5 w-5 stroke-gray-500 dark:stroke-zinc-400`}
+        />
+      </div>
+      <div
+        className={`text-gray-600 text-sm ml-2 lg:text-md`}
+      >
+        {"No FCEs available for the selected settings"}
+      </div>
+    </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Adds a "No FCEs available" message whenever the user attempts to view FCE data that doesn't exist. For example, FCEs may not be available yet for a certain class, or the user may have limited their aggregate FCE data settings such that no FCEs exist for the specified time period. 

Closes #20 