### PR TITLE
Allow "Semesters to Show" field to be temporarily blank

### DIFF
--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -4,7 +4,7 @@ import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { userSlice } from "../app/user";
 import { Semester } from "../app/types";
 
-const numeric = /\d/;
+const numericRegex = /\d/;
 const numSemsDispatchableRegex = /\d+/g;
 
 const Aggregate = () => {

--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -4,6 +4,9 @@ import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { userSlice } from "../app/user";
 import { Semester } from "../app/types";
 
+const numeric = /\d/;
+const numSemsDispatchableRegex = /\d+/g;
+
 const Aggregate = () => {
   const dispatch = useAppDispatch();
 
@@ -18,6 +21,38 @@ const Aggregate = () => {
     (state) => state.user.fceAggregation.numSemesters
   );
 
+  const [numSemsField, setNumSemsField] = React.useState<number | undefined>(
+    undefined
+  );
+
+  React.useEffect(() => {
+    setNumSemsField(numSemesters);
+  }, [numSemesters]);
+
+  const handleNumSemsFieldKeyDown: React.KeyboardEventHandler<
+    HTMLInputElement
+  > = (e) => {
+    if (!numeric.test(e.key)) {
+      e.preventDefault();
+    }
+  };
+
+  const handleNumSemsFieldChange: React.ChangeEventHandler<HTMLInputElement> = (
+    e
+  ) => {
+    if (numSemsDispatchableRegex.test(e.target.value)) {
+      setNumSemesters(parseInt(e.target.value));
+    } else if (e.target.value === "") {
+      setNumSemsField(undefined);
+    }
+  };
+
+  const handleNumSemsFieldBlur: React.FocusEventHandler<
+    HTMLInputElement
+  > = () => {
+    if (numSemsField === undefined) setNumSemsField(numSemesters);
+  };
+
   return (
     <div>
       <div className="text-lg">Aggregate FCEs</div>
@@ -28,11 +63,11 @@ const Aggregate = () => {
           </div>
           <input
             type="number"
-            value={numSemesters}
+            value={numSemsField === undefined ? "" : numSemsField}
             className="border-gray-200 min-w-0 flex-auto rounded border px-2 py-1 text-sm bg-transparent"
-            onChange={(e) => {
-              setNumSemesters(parseInt(e.target.value));
-            }}
+            onChange={handleNumSemsFieldChange}
+            onBlur={handleNumSemsFieldBlur}
+            onKeyPress={handleNumSemsFieldKeyDown}
           />
         </div>
         <div className="flex flex-row justify-between text-sm">

--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -26,17 +26,24 @@ const NumericInput = (props: NumericInputProps) => {
       setIsBlank(false);
       onChange(parseInt(e.target.value));
     } else if (e.target.value === "") {
-      // note: this also happens when there is non-numeric input!
+      // note: if we were to not handleKeyPress, handleChange would also be
+      // called when the user enters some non-numeric input, with
+      // e.target.value === ""
+
       // limitation of input[type=number]
       setIsBlank(true);
     }
   };
 
+  // only allow field to be temporarily blank
+  // on unfocus, reset to last valid value
   const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
     if (isBlank) setIsBlank(false);
     if (onBlur) onBlur(e);
   };
 
+  // this is only called when a key that creates a character is pressed (for
+  // example symbols and alphabets; NOT backspace, arrow keys, Alt/Ctrl etc)
   const handleKeyPress: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (!numericRegex.test(e.key)) e.preventDefault();
   };

--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -21,14 +21,17 @@ const Aggregate = () => {
     (state) => state.user.fceAggregation.numSemesters
   );
 
+  // Auxiliary local state required to handle the case when the field is (temporarily) blank
   const [numSemsField, setNumSemsField] = React.useState<number | undefined>(
     undefined
   );
 
+  // To update the global state
   React.useEffect(() => {
     setNumSemsField(numSemesters);
   }, [numSemesters]);
 
+  /* Needed to prevent non-numeric input from being entered by the user. */
   const handleNumSemsFieldKeyDown: React.KeyboardEventHandler<
     HTMLInputElement
   > = (e) => {
@@ -47,6 +50,7 @@ const Aggregate = () => {
     }
   };
 
+  // Restore the last valid value if the field is left blank and unfocused
   const handleNumSemsFieldBlur: React.FocusEventHandler<
     HTMLInputElement
   > = () => {

--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -5,7 +5,7 @@ import { userSlice } from "../app/user";
 import { Semester } from "../app/types";
 
 const numericRegex = /\d/;
-const numericNonemptyRegex = /\d+/g;
+const numericNonemptyRegex = /^\d+$/;
 
 interface NumericInputProps
   extends Omit<
@@ -32,6 +32,8 @@ const NumericInput = (props: NumericInputProps) => {
 
       // limitation of input[type=number]
       setIsBlank(true);
+    } else {
+      console.log("weird edge case");
     }
   };
 
@@ -45,6 +47,7 @@ const NumericInput = (props: NumericInputProps) => {
   // this is only called when a key that creates a character is pressed (for
   // example symbols and alphabets; NOT backspace, arrow keys, Alt/Ctrl etc)
   const handleKeyPress: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    console.log("test");
     if (!numericRegex.test(e.key)) e.preventDefault();
   };
 

--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -1,11 +1,57 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { SEMESTERS_COUNTED } from "../app/constants";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { userSlice } from "../app/user";
 import { Semester } from "../app/types";
 
 const numericRegex = /\d/;
-const numSemsDispatchableRegex = /\d+/g;
+const numericNonemptyRegex = /\d+/g;
+
+interface NumericInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "type" | "value" | "onChange" | "onKeyPress"
+  > {
+  value: number;
+  onChange: (_: number) => void;
+  className: string;
+}
+
+const NumericInput = (props: NumericInputProps) => {
+  const { value, onChange, onBlur, ...other } = props;
+  const [isBlank, setIsBlank] = useState(false);
+
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (numericNonemptyRegex.test(e.target.value)) {
+      setIsBlank(false);
+      onChange(parseInt(e.target.value));
+    } else if (e.target.value === "") {
+      // note: this also happens when there is non-numeric input!
+      // limitation of input[type=number]
+      setIsBlank(true);
+    }
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    if (isBlank) setIsBlank(false);
+    if (onBlur) onBlur(e);
+  };
+
+  const handleKeyPress: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (!numericRegex.test(e.key)) e.preventDefault();
+  };
+
+  return (
+    <input
+      type="number"
+      value={isBlank ? "" : String(value)}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onKeyPress={handleKeyPress}
+      {...other}
+    />
+  );
+};
 
 const Aggregate = () => {
   const dispatch = useAppDispatch();
@@ -21,42 +67,6 @@ const Aggregate = () => {
     (state) => state.user.fceAggregation.numSemesters
   );
 
-  // Auxiliary local state required to handle the case when the field is (temporarily) blank
-  const [numSemsField, setNumSemsField] = React.useState<number | undefined>(
-    undefined
-  );
-
-  // To update the global state
-  React.useEffect(() => {
-    setNumSemsField(numSemesters);
-  }, [numSemesters]);
-
-  /* Needed to prevent non-numeric input from being entered by the user. */
-  const handleNumSemsFieldKeyDown: React.KeyboardEventHandler<
-    HTMLInputElement
-  > = (e) => {
-    if (!numeric.test(e.key)) {
-      e.preventDefault();
-    }
-  };
-
-  const handleNumSemsFieldChange: React.ChangeEventHandler<HTMLInputElement> = (
-    e
-  ) => {
-    if (numSemsDispatchableRegex.test(e.target.value)) {
-      setNumSemesters(parseInt(e.target.value));
-    } else if (e.target.value === "") {
-      setNumSemsField(undefined);
-    }
-  };
-
-  // Restore the last valid value if the field is left blank and unfocused
-  const handleNumSemsFieldBlur: React.FocusEventHandler<
-    HTMLInputElement
-  > = () => {
-    if (numSemsField === undefined) setNumSemsField(numSemesters);
-  };
-
   return (
     <div>
       <div className="text-lg">Aggregate FCEs</div>
@@ -65,13 +75,10 @@ const Aggregate = () => {
           <div className="mr-4 whitespace-nowrap text-sm">
             Semesters to Show
           </div>
-          <input
-            type="number"
-            value={numSemsField === undefined ? "" : numSemsField}
+          <NumericInput
+            value={numSemesters}
             className="border-gray-200 min-w-0 flex-auto rounded border px-2 py-1 text-sm bg-transparent"
-            onChange={handleNumSemsFieldChange}
-            onBlur={handleNumSemsFieldBlur}
-            onKeyPress={handleNumSemsFieldKeyDown}
+            onChange={setNumSemesters}
           />
         </div>
         <div className="flex flex-row justify-between text-sm">

--- a/frontend/src/components/ScheduleData.tsx
+++ b/frontend/src/components/ScheduleData.tsx
@@ -62,8 +62,6 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
       );
   };
 
-  console.log(aggregatedSelectedData);
-
   return (
     <>
       <div className="flex items-end justify-between">


### PR DESCRIPTION
Should fix #76.

This allows backspacing to work as a user might expect; i.e. they can clear the field and enter a new value. If the user leaves the field blank and unfocuses the field, it will revert back to its last valid value.

This was more complicated to implement than expected. An auxiliary state has to be implemented to handle the case when the field is temporarily blank (a future developer may be able to address this). This auxiliary state updates the global state (i.e. calls the dispatch function) through a useEffect hook.

In addition, due to the limitations of the input[type=number] element, we need to add a onKeyPress handler to disable key presses for non-numeric keys, as the onChange handler cannot detect when non-numeric input is given to the field.

# Description

Closes #76 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

- Node.js version: 18.9.0
- Desktop/Mobile: Desktop
- OS: Linux 5.19.0 (EndeavourOS)
- Browser: Firefox 105.0.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
