### PR TITLE
Allow omission of hyphen when searching by course ID in ScheduleSearch

### DIFF
--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -4,6 +4,9 @@ import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { userSlice } from "../app/user";
 import { Semester } from "../app/types";
 
+const numeric = /\d/;
+const numSemsDispatchableRegex = /\d+/g;
+
 const Aggregate = () => {
   const dispatch = useAppDispatch();
 
@@ -18,6 +21,38 @@ const Aggregate = () => {
     (state) => state.user.fceAggregation.numSemesters
   );
 
+  const [numSemsField, setNumSemsField] = React.useState<number | undefined>(
+    undefined
+  );
+
+  React.useEffect(() => {
+    setNumSemsField(numSemesters);
+  }, [numSemesters]);
+
+  const handleNumSemsFieldKeyDown: React.KeyboardEventHandler<
+    HTMLInputElement
+  > = (e) => {
+    if (!numeric.test(e.key)) {
+      e.preventDefault();
+    }
+  };
+
+  const handleNumSemsFieldChange: React.ChangeEventHandler<HTMLInputElement> = (
+    e
+  ) => {
+    if (numSemsDispatchableRegex.test(e.target.value)) {
+      setNumSemesters(parseInt(e.target.value));
+    } else if (e.target.value === "") {
+      setNumSemsField(undefined);
+    }
+  };
+
+  const handleNumSemsFieldBlur: React.FocusEventHandler<
+    HTMLInputElement
+  > = () => {
+    if (numSemsField === undefined) setNumSemsField(numSemesters);
+  };
+
   return (
     <div>
       <div className="text-lg">Aggregate FCEs</div>
@@ -28,11 +63,11 @@ const Aggregate = () => {
           </div>
           <input
             type="number"
-            value={numSemesters}
+            value={numSemsField === undefined ? "" : numSemsField}
             className="border-gray-200 min-w-0 flex-auto rounded border px-2 py-1 text-sm bg-transparent"
-            onChange={(e) => {
-              setNumSemesters(parseInt(e.target.value));
-            }}
+            onChange={handleNumSemsFieldChange}
+            onBlur={handleNumSemsFieldBlur}
+            onKeyPress={handleNumSemsFieldKeyDown}
           />
         </div>
         <div className="flex flex-row justify-between text-sm">

--- a/frontend/src/components/Aggregate.tsx
+++ b/frontend/src/components/Aggregate.tsx
@@ -21,14 +21,17 @@ const Aggregate = () => {
     (state) => state.user.fceAggregation.numSemesters
   );
 
+  // Auxiliary local state required to handle the case when the field is (temporarily) blank
   const [numSemsField, setNumSemsField] = React.useState<number | undefined>(
     undefined
   );
 
+  // To update the global state
   React.useEffect(() => {
     setNumSemsField(numSemesters);
   }, [numSemesters]);
 
+  /* Needed to prevent non-numeric input from being entered by the user. */
   const handleNumSemsFieldKeyDown: React.KeyboardEventHandler<
     HTMLInputElement
   > = (e) => {
@@ -47,6 +50,7 @@ const Aggregate = () => {
     }
   };
 
+  // Restore the last valid value if the field is left blank and unfocused
   const handleNumSemsFieldBlur: React.FocusEventHandler<
     HTMLInputElement
   > = () => {

--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtual } from "react-virtual";
 import {
   useCombobox,
@@ -32,8 +32,20 @@ const CourseCombobox = ({
   const listRef = useRef();
   const dispatch = useAppDispatch();
 
-  const allCourses = useAppSelector((state) => state.cache.allCourses);
   const activeSchedule = useAppSelector(selectCoursesInActiveSchedule);
+
+  const allCourses = useAppSelector((state) => state.cache.allCourses);
+
+  // allow searching for course IDs without the hyphen
+  const allCoursesSearchable = useMemo(
+    () =>
+      allCourses.map((course) => ({
+        courseID: course.courseID,
+        courseIDDehyphenated: course.courseID.replace("-", ""),
+        name: course.name,
+      })),
+    [allCourses]
+  );
 
   useEffect(() => {
     void dispatch(fetchAllCourses());
@@ -46,9 +58,10 @@ const CourseCombobox = ({
   }, [activeSchedule]);
 
   function getCourses() {
-    return allCourses.filter(
+    return allCoursesSearchable.filter(
       (course) =>
         (course.courseID.includes(inputValue) ||
+          course.courseIDDehyphenated.includes(inputValue) ||
           course.name.toLowerCase().includes(inputValue)) &&
         selectedItems.map(({ courseID }) => courseID).indexOf(course.courseID) <
           0


### PR DESCRIPTION
# Description

This allows you to omit the hyphen when searching by course ID while adding courses to your schedule.

Closes #74 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

**Test Configuration**:

- Node.js version: 18.9.0
- Desktop/Mobile: Desktop
- OS: Linux 5.19.0 (EndeavourOS)
- Browser: Firefox 105.0.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
