### PR TITLE
Simplified implementation of omitted hyphen

### DIFF
--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -23,6 +23,8 @@ type selectedItem = {
   name: string;
 };
 
+const unhyphenatedCourseCodeRegex = /(\d{2})(\d{1,3})/g;
+
 const CourseCombobox = ({
   onSelectedItemsChange,
 }: {
@@ -46,9 +48,13 @@ const CourseCombobox = ({
   }, [activeSchedule]);
 
   function getCourses() {
+    // hyphenates 3 to 5 digit numbers, e.g. 152 -> 15-2, 1521 -> 15-21, 15213 -> 15-213
+    // otherwise, input value remains the same
+    const hyphenated = inputValue.replace(unhyphenatedCourseCodeRegex, "$1-$2");
     return allCourses.filter(
       (course) =>
         (course.courseID.includes(inputValue) ||
+          course.courseID.includes(hyphenated) ||
           course.name.toLowerCase().includes(inputValue)) &&
         selectedItems.map(({ courseID }) => courseID).indexOf(course.courseID) <
           0

--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -53,8 +53,7 @@ const CourseCombobox = ({
     const hyphenated = inputValue.replace(unhyphenatedCourseCodeRegex, "$1-$2");
     return allCourses.filter(
       (course) =>
-        (course.courseID.includes(inputValue) ||
-          course.courseID.includes(hyphenated) ||
+        (course.courseID.includes(hyphenated) ||
           course.name.toLowerCase().includes(inputValue)) &&
         selectedItems.map(({ courseID }) => courseID).indexOf(course.courseID) <
           0


### PR DESCRIPTION
Now hyphenates parts of a all-numeric course code (e.g. 152 -> 15-2, 1521 -> 15-21, 15213 -> 15-213).

# Description

Closes #74

Replaces GH-78.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
