### PR TITLE
Hotfix for ScheduleSearch not matching full course ID

### DIFF
--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -23,7 +23,7 @@ type selectedItem = {
   name: string;
 };
 
-const unhyphenatedCourseCodeRegex = /(\d{2})(\d{1,3})/g;
+const unhyphenatedCourseCodeRegex = /^(\d{2})(\d{1,3})/g;
 
 const CourseCombobox = ({
   onSelectedItemsChange,


### PR DESCRIPTION
# Description
15150 matches but 15-150 doesn't, because 15-150 -> 15-15-0

This should fix it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
