### PR TITLE
Activate the department & unit filters on interaction

### DIFF
--- a/frontend/src/components/Filter.tsx
+++ b/frontend/src/components/Filter.tsx
@@ -18,6 +18,7 @@ const DepartmentFilter = () => {
 
   const setDepartments = (departments: string[]) => {
     dispatch(filtersSlice.actions.updateDepartments(departments));
+    dispatch(filtersSlice.actions.updateDepartmentsActive(true));
     throttledFilter();
   };
 
@@ -164,6 +165,7 @@ const UnitsFilter = () => {
                     value as [number, number]
                   )
                 );
+                dispatch(filtersSlice.actions.updateUnitsActive(true));
                 if (active) throttledFilter();
               }}
             />


### PR DESCRIPTION
## Description

When a department is chosen from the dropdown, the department checkbox is set to true. Similarly, when the unit range selector is changed, the unit checkbox is set to true.

Non-breaking change.

Closes #47