### PR TITLE
Fix schedule search

### DIFF
--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -165,7 +165,7 @@ const CourseCombobox = ({
             </div>
           ))}
         </div>
-        <div {...getComboboxProps()} className="w-full flex-1">
+        <div {...getComboboxProps()} className="w-full flex-1 flex-wrap">
           <div className="relative flex w-full border-b border-b-gray-300">
             <span className="absolute inset-y-0 left-0 flex items-center">
               <MagnifyingGlassIcon className="h-5 w-5" />

--- a/frontend/src/components/ScheduleSearch.tsx
+++ b/frontend/src/components/ScheduleSearch.tsx
@@ -142,7 +142,7 @@ const CourseCombobox = ({
       <div>
         <label {...getLabelProps()} />
       </div>
-      <div className="relative mt-2 flex flex-col items-baseline space-y-2 md:mt-0 md:flex-row md:space-y-0">
+      <div className="relative mt-2 flex flex-col items-baseline space-y-2 md:mt-0 md:flex-row md:flex-wrap md:space-y-0">
         <div className="flex w-full max-w-full overflow-x-auto md:w-auto md:flex-none">
           {selectedItems.map((selectedItem, index) => (
             <div
@@ -165,7 +165,7 @@ const CourseCombobox = ({
             </div>
           ))}
         </div>
-        <div {...getComboboxProps()} className="w-full flex-1 flex-wrap">
+        <div {...getComboboxProps()} className="w-full flex-1">
           <div className="relative flex w-full border-b border-b-gray-300">
             <span className="absolute inset-y-0 left-0 flex items-center">
               <MagnifyingGlassIcon className="h-5 w-5" />


### PR DESCRIPTION
# Description
Adds a `flex-wrap` property to the search so that the search bar spills to the next line instead of going off the page.

Closes #94 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally, added a bunch of courses to see if the search bar goes off.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
