### PR TITLE
Upgrade Prisma Client to 5.6 - Resolves Unit Filter Bug

### DIFF
--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,6 +1,6 @@
 {
   "execMap": {
-    "ts": "ts-node-esm"
+    "ts": "node --loader ts-node/esm -r dotenv/config"
   },
   "ext": "js,ts,json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/client": "^4.12.0",
+        "@prisma/client": "^5.6.0",
         "dotenv": "^16.3.1",
-        "prisma": "^4.12.0",
         "typescript": "^5.0.4"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "eslint-config-prettier": "^8.8.0",
-        "prettier": "^2.8.7"
+        "prettier": "^2.8.7",
+        "prisma": "^5.6.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -148,15 +148,15 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.12.0.tgz",
-      "integrity": "sha512-j9/ighfWwux97J2dS15nqhl60tYoH8V0IuSsgZDb6bCFcQD3fXbXmxjYC8GHhIgOk3lB7Pq+8CwElz2MiDpsSg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.6.0.tgz",
+      "integrity": "sha512-mUDefQFa1wWqk4+JhKPYq8BdVoFk9NFMBXUI8jAkBfQTtgx8WPx02U2HB/XbAz3GSUJpeJOKJQtNvaAIDs6sug==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7"
+        "@prisma/engines-version": "5.6.0-32.e95e739751f42d8ca026f6b910f5a2dc5adeaeee"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -168,15 +168,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.12.0.tgz",
-      "integrity": "sha512-0alKtnxhNB5hYU+ymESBlGI4b9XrGGSdv7Ud+8TE/fBNOEhIud0XQsAR+TrvUZgS4na5czubiMsODw0TUrgkIA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.6.0.tgz",
+      "integrity": "sha512-Mt2q+GNJpU2vFn6kif24oRSBQv1KOkYaterQsi0k2/lA+dLvhRX6Lm26gon6PYHwUM8/h8KRgXIUMU0PCLB6bw==",
+      "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7.tgz",
-      "integrity": "sha512-JIHNj5jlXb9mcaJwakM0vpgRYJIAurxTUqM0iX0tfEQA5XLZ9ONkIckkhuAKdAzocZ+80GYg7QSsfpjg7OxbOA=="
+      "version": "5.6.0-32.e95e739751f42d8ca026f6b910f5a2dc5adeaeee",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.6.0-32.e95e739751f42d8ca026f6b910f5a2dc5adeaeee.tgz",
+      "integrity": "sha512-UoFgbV1awGL/3wXuUK3GDaX2SolqczeeJ5b4FVec9tzeGbSWJboPSbT0psSrmgYAKiKnkOPFSLlH6+b+IyOwAw=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -1438,19 +1439,19 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.12.0.tgz",
-      "integrity": "sha512-xqVper4mbwl32BWzLpdznHAYvYDWQQWK2tBfXjdUD397XaveRyAP7SkBZ6kFlIg8kKayF4hvuaVtYwXd9BodAg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.6.0.tgz",
+      "integrity": "sha512-EEaccku4ZGshdr2cthYHhf7iyvCcXqwJDvnoQRAJg5ge2Tzpv0e2BaMCp+CbbDUwoVTzwgOap9Zp+d4jFa2O9A==",
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.12.0"
+        "@prisma/engines": "5.6.0"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       }
     },
     "node_modules/punycode": {
@@ -1543,9 +1544,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1733,9 +1734,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "eslint-config-prettier": "^8.8.0",
-    "prettier": "^2.8.7"
+    "prettier": "^2.8.7",
+    "prisma": "^5.6.0"
   },
   "dependencies": {
-    "@prisma/client": "^4.12.0",
+    "@prisma/client": "^5.6.0",
     "dotenv": "^16.3.1",
-    "prisma": "^4.12.0",
     "typescript": "^5.0.4"
   }
 }


### PR DESCRIPTION
# Description
Quick upgrade to Prisma Client from its 4.12 to 5.6. Addresses the bug where the unit count filter was broken. 
May need to regenerate database with "npm run db-generate".

Closes #124 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version:
- Python version:
- Desktop/Mobile:
- OS:
- Browser:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
