### PR TITLE
Department filter search

### DIFF
--- a/frontend/src/app/filters.ts
+++ b/frontend/src/app/filters.ts
@@ -8,7 +8,6 @@ export interface FiltersState {
     active: boolean;
     names: string[];
     query: string;
-    searchOn: boolean;
   };
   units: {
     active: boolean;
@@ -31,7 +30,6 @@ const initialState: FiltersState = {
     active: false,
     names: [],
     query: "",
-    searchOn: false,
   },
   units: {
     active: false,
@@ -79,9 +77,6 @@ export const filtersSlice = createSlice({
     },
     updateDepartmentsQuery: (state, action: PayloadAction<string>) => {
       state.departments.query = action.payload;
-    },
-    updateDepartmentsSearchOn: (state, action: PayloadAction<boolean>) => {
-      state.departments.searchOn = action.payload;
     },
     updateSemestersActive: (state, action: PayloadAction<boolean>) => {
       state.semesters.active = action.payload;

--- a/frontend/src/app/filters.ts
+++ b/frontend/src/app/filters.ts
@@ -7,6 +7,8 @@ export interface FiltersState {
   departments: {
     active: boolean;
     names: string[];
+    query: string;
+    searchOn: boolean;
   };
   units: {
     active: boolean;
@@ -28,6 +30,8 @@ const initialState: FiltersState = {
   departments: {
     active: false,
     names: [],
+    query: "",
+    searchOn: false,
   },
   units: {
     active: false,
@@ -72,6 +76,12 @@ export const filtersSlice = createSlice({
     },
     updateDepartments: (state, action: PayloadAction<string[]>) => {
       state.departments.names = action.payload;
+    },
+    updateDepartmentsQuery: (state, action: PayloadAction<string>) => {
+      state.departments.query = action.payload;
+    },
+    updateDepartmentsSearchOn: (state, action: PayloadAction<boolean>) => {
+      state.departments.searchOn = action.payload;
     },
     updateSemestersActive: (state, action: PayloadAction<boolean>) => {
       state.semesters.active = action.payload;

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -11,7 +11,7 @@ import { DEPARTMENTS } from "../../app/constants";
 const DepartmentFilter = () => {
   const dispatch = useAppDispatch();
 
-  const { active, names, query, searchOn } = useAppSelector(
+  const { active, names, query } = useAppSelector(
     (state) => state.filters.departments
   );
 

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -84,6 +84,11 @@ const DepartmentFilter = () => {
                   deleteDepartment(names[names.length - 1]);
                 } else if (e.key === " ") {
                   dispatch(filtersSlice.actions.updateDepartmentsQuery(query + " science"));
+                } else if (e.key === "Tab") {
+                  let department = DEPARTMENTS.filter(searchDepartments)[0].name;
+                  if (!names.includes(department)) {
+                    setDepartments(names.concat([department]));
+                  }
                 }
               }}
               onKeyUp={(e) => {

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -7,6 +7,8 @@ import { throttledFilter } from "../../app/store";
 import { Combobox } from "@headlessui/react";
 import { classNames, getDepartmentByName } from "../../app/utils";
 import { DEPARTMENTS } from "../../app/constants";
+import {Simulate} from "react-dom/test-utils";
+import click = Simulate.click;
 
 const DepartmentFilter = () => {
   const dispatch = useAppDispatch();
@@ -82,6 +84,13 @@ const DepartmentFilter = () => {
               onKeyDown={(e) => {
                 if (e.key === "Backspace" && query.length === 0 && names.length > 0) {
                   deleteDepartment(names[names.length - 1]);
+                } else if (e.key === " ") {
+                  dispatch(filtersSlice.actions.updateDepartmentsQuery(query + " science"));
+                }
+              }}
+              onKeyUp={(e) => {
+                if (e.key === " ") {
+                  e.preventDefault();
                 }
               }}
             />

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -7,8 +7,6 @@ import { throttledFilter } from "../../app/store";
 import { Combobox } from "@headlessui/react";
 import { classNames, getDepartmentByName } from "../../app/utils";
 import { DEPARTMENTS } from "../../app/constants";
-import {Simulate} from "react-dom/test-utils";
-import click = Simulate.click;
 
 const DepartmentFilter = () => {
   const dispatch = useAppDispatch();

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -79,19 +79,19 @@ const DepartmentFilter = () => {
             <Combobox.Input
               className="shadow-xs bg-white rounded py-0.5 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5 flex"
               onChange={(e) => dispatch(filtersSlice.actions.updateDepartmentsQuery(e.target.value))}
-              onKeyDown={(e) => {
+              onKeyDown={(e : React.KeyboardEvent) => {
                 if (e.key === "Backspace" && query.length === 0 && names.length > 0) {
                   deleteDepartment(names[names.length - 1]);
                 } else if (e.key === " ") {
                   dispatch(filtersSlice.actions.updateDepartmentsQuery(query + " science"));
                 } else if (e.key === "Tab") {
-                  let department = DEPARTMENTS.filter(searchDepartments)[0].name;
+                  const department = DEPARTMENTS.filter(searchDepartments)[0].name;
                   if (!names.includes(department)) {
                     setDepartments(names.concat([department]));
                   }
                 }
               }}
-              onKeyUp={(e) => {
+              onKeyUp={(e : React.KeyboardEvent) => {
                 if (e.key === " ") {
                   e.preventDefault();
                 }

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -57,7 +57,7 @@ const DepartmentFilter = () => {
           className="border-gray-200 relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out sm:text-sm sm:leading-5">
           <span className="flex flex-wrap gap-1">
             {names.length === 0 ? (
-              !searchOn && <span className="p-0.5">None</span>
+              query.length === 0 && <span className="p-0.5">None</span>
             ) : (
               names.map((department) => (
                 <span

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -55,7 +55,7 @@ const DepartmentFilter = () => {
         </Combobox.Label>
         <Combobox.Button
           className="border-gray-200 relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out sm:text-sm sm:leading-5">
-          <span className="block flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             {names.length === 0 ? (
               !searchOn && <span className="p-0.5">None</span>
             ) : (
@@ -77,7 +77,7 @@ const DepartmentFilter = () => {
               ))
             )}
             <Combobox.Input
-              className="shadow-xs bg-white rounded py-0.5 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
+              className="shadow-xs bg-white rounded py-0.5 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5 flex"
               onFocus={() => dispatch(filtersSlice.actions.updateDepartmentsSearchOn(true))}
               onBlur={() => dispatch(filtersSlice.actions.updateDepartmentsSearchOn(false))}
               onChange={(e) => dispatch(filtersSlice.actions.updateDepartmentsQuery(e.target.value))}

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -4,14 +4,14 @@ import { CheckIcon } from "@heroicons/react/20/solid";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { filtersSlice } from "../../app/filters";
 import { throttledFilter } from "../../app/store";
-import { Listbox } from "@headlessui/react";
+import { Combobox } from "@headlessui/react";
 import { classNames, getDepartmentByName } from "../../app/utils";
 import { DEPARTMENTS } from "../../app/constants";
 
 const DepartmentFilter = () => {
   const dispatch = useAppDispatch();
 
-  const { active, names } = useAppSelector(
+  const { active, names, query, searchOn } = useAppSelector(
     (state) => state.filters.departments
   );
 
@@ -26,10 +26,18 @@ const DepartmentFilter = () => {
     throttledFilter();
   };
 
+  const searchDepartments = (department: { name: string, shortName: string, prefix: string }) => {
+    const searchTerm = query.toLowerCase();
+
+    return department.name.toLowerCase().includes(searchTerm) ||
+      department.shortName.toLowerCase().includes(searchTerm) ||
+      department.prefix.toLowerCase().includes(searchTerm);
+  }
+
   return (
     <div className="relative mt-1">
-      <Listbox value={names} onChange={setDepartments} multiple>
-        <Listbox.Label className="flex">
+      <Combobox value={names} onChange={setDepartments} multiple>
+        <Combobox.Label className="flex">
           <div>
             <input
               type="checkbox"
@@ -44,11 +52,12 @@ const DepartmentFilter = () => {
             />
           </div>
           Department
-        </Listbox.Label>
-        <Listbox.Button className="border-gray-200 relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out sm:text-sm sm:leading-5">
+        </Combobox.Label>
+        <Combobox.Button
+          className="border-gray-200 relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out sm:text-sm sm:leading-5">
           <span className="block flex flex-wrap gap-1">
             {names.length === 0 ? (
-              <span className="p-0.5">None</span>
+              !searchOn && <span className="p-0.5">None</span>
             ) : (
               names.map((department) => (
                 <span
@@ -67,15 +76,23 @@ const DepartmentFilter = () => {
                 </span>
               ))
             )}
+            <Combobox.Input
+              className="shadow-xs bg-white rounded py-0.5 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
+              onFocus={() => dispatch(filtersSlice.actions.updateDepartmentsSearchOn(true))}
+              onBlur={() => dispatch(filtersSlice.actions.updateDepartmentsSearchOn(false))}
+              onChange={(e) => dispatch(filtersSlice.actions.updateDepartmentsQuery(e.target.value))}
+            />
           </span>
           <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
             <ChevronUpDownIcon className="h-5 w-5 stroke-gray-500 dark:stroke-zinc-400" />
           </span>
-        </Listbox.Button>
+        </Combobox.Button>
         <div className="bg-white absolute mt-1 w-full rounded shadow-lg">
-          <Listbox.Options className="shadow-xs bg-white relative z-50 max-h-60 overflow-auto rounded py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
-            {DEPARTMENTS.map(({ name, prefix }) => (
-              <Listbox.Option
+          <Combobox.Options
+            className="shadow-xs bg-white relative z-50 max-h-60 overflow-auto rounded py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
+          >
+            {DEPARTMENTS.filter(searchDepartments).map(({ name, prefix }) => (
+              <Combobox.Option
                 key={name}
                 value={name}
                 className="relative cursor-pointer select-none py-2 pl-3 pr-9 focus:outline-none "
@@ -103,11 +120,11 @@ const DepartmentFilter = () => {
                     )}
                   </>
                 )}
-              </Listbox.Option>
+              </Combobox.Option>
             ))}
-          </Listbox.Options>
+          </Combobox.Options>
         </div>
-      </Listbox>
+      </Combobox>
     </div>
   );
 };

--- a/frontend/src/components/filters/DepartmentFilter.tsx
+++ b/frontend/src/components/filters/DepartmentFilter.tsx
@@ -78,9 +78,12 @@ const DepartmentFilter = () => {
             )}
             <Combobox.Input
               className="shadow-xs bg-white rounded py-0.5 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5 flex"
-              onFocus={() => dispatch(filtersSlice.actions.updateDepartmentsSearchOn(true))}
-              onBlur={() => dispatch(filtersSlice.actions.updateDepartmentsSearchOn(false))}
               onChange={(e) => dispatch(filtersSlice.actions.updateDepartmentsQuery(e.target.value))}
+              onKeyDown={(e) => {
+                if (e.key === "Backspace" && query.length === 0 && names.length > 0) {
+                  deleteDepartment(names[names.length - 1]);
+                }
+              }}
             />
           </span>
           <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added text input to filter department search for ease of use. Met a number of technical and styling challenges, but I believe this is the best that can be done for now.

Backspace deletes filters, tab autofills the first option if in input mode.

Closes #133 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Type in search query without spaces
- [x] Type in search query with spaces (this was initially an issue)
- [x] Add multiple options under the same query
- [x] Change query after selecting options (query is cleared when reselecting the input)
- [x] Exiting the input clears the query
- [x] Backspace deletes the filters until there are non left
- [x] If in input mode, tab autofills the first option and exits input mode

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: v18.18.0
- Desktop: MacBook Air M2
- OS: MacOS Sonoma
- Browser: Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
