### PR TITLE
Schedules Page Improvements

### DIFF
--- a/frontend/src/app/ui.ts
+++ b/frontend/src/app/ui.ts
@@ -7,6 +7,7 @@ export interface UIState {
     loginModalShown: boolean;
     loginModalOpen: boolean;
   };
+  schedulesTopbarOpen: boolean;
 }
 
 const initialState: UIState = {
@@ -16,6 +17,7 @@ const initialState: UIState = {
     loginModalShown: false,
     loginModalOpen: false,
   },
+  schedulesTopbarOpen: false,
 };
 
 export const uiSlice = createSlice({
@@ -34,6 +36,9 @@ export const uiSlice = createSlice({
     closeLoginModal: (state) => {
       state.session.loginModalShown = true;
       state.session.loginModalOpen = false;
+    },
+    toggleSchedulesTopbarOpen: (state) => {
+      state.schedulesTopbarOpen = !state.schedulesTopbarOpen;
     },
   },
 });

--- a/frontend/src/components/CourseList.tsx
+++ b/frontend/src/components/CourseList.tsx
@@ -37,6 +37,7 @@ const CourseList = ({ courseIDs, children }: Props) => {
               key={course.courseID}
               showFCEs={true}
               showCourseInfo={true}
+              showSchedules={true}
             />
           ))}
         </div>

--- a/frontend/src/components/ScheduleData.tsx
+++ b/frontend/src/components/ScheduleData.tsx
@@ -28,6 +28,8 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
     selectFCEResultsForCourses(scheduled || [])
   );
 
+  const open = useAppSelector((state) => state.ui.schedulesTopbarOpen);
+
   if (!loggedIn) {
     return (
       <div className="bg-white text-gray-700 z-10">
@@ -64,8 +66,6 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
         userSchedulesSlice.actions.deselectCourseInActiveSchedule(courseID)
       );
   };
-
-  const open = useAppSelector((state) => state.ui.schedulesTopbarOpen);
 
   return (
     <>

--- a/frontend/src/components/ScheduleData.tsx
+++ b/frontend/src/components/ScheduleData.tsx
@@ -7,6 +7,9 @@ import {
   selectSelectedCoursesInActiveSchedule,
   userSchedulesSlice,
 } from "../app/userSchedules";
+import { FlushedButton } from "./Buttons";
+import { uiSlice } from "../app/ui";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/20/solid";
 
 type ScheduleDataProps = {
   scheduled: string[];
@@ -62,6 +65,8 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
       );
   };
 
+  const open = useAppSelector((state) => state.ui.schedulesTopbarOpen);
+
   return (
     <>
       <div className="flex items-end justify-between">
@@ -69,29 +74,39 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
           <div className="text-a-600 text-lg">
             Total Workload{" "}
             <span className="ml-4">
-              {roundTo(aggregatedSelectedData.workload, 2)} hrs/week
+              {scheduledResults.reduce((acc, curr) => acc + parseInt(curr.units), 0)} units,
               {message === "" ? "" : "*"}
             </span>
             <span className="ml-4">
-              {scheduledResults.reduce((acc, curr) => acc + parseInt(curr.units), 0)} units
+              {roundTo(aggregatedSelectedData.workload, 2)} hrs/week
               {message === "" ? "" : "*"}
             </span>
+            <button className="absolute right-3 z-40 md:right-2">
+              <FlushedButton
+                onClick={() => dispatch(uiSlice.actions.toggleSchedulesTopbarOpen())}
+              >
+                <div className="hidden items-center md:flex">
+                  <div className="mr-1">Hide</div>
+                  {(open ? <ChevronDownIcon className="h-5 w-5" /> : <ChevronUpIcon className="h-5 w-5" />)}
+                </div>
+              </FlushedButton>
+            </button>
           </div>
         </div>
       </div>
-      <div className="mt-3 w-full overflow-x-auto">
+      {(open && <div className="mt-3 w-full overflow-x-auto">
         <table className="w-full min-w-fit table-auto overflow-x-scroll">
           <thead>
-            <tr className="text-left">
-              <th />
-              <th className="whitespace-nowrap pr-4 font-semibold">
-                Course ID
-              </th>
-              <th className="whitespace-nowrap pr-4 font-semibold">
-                Course Name
-              </th>
-              <th className="whitespace-nowrap pr-4 font-semibold">Units</th>
-              <th className="whitespace-nowrap pr-4 font-semibold">Workload</th>
+          <tr className="text-left">
+            <th />
+            <th className="whitespace-nowrap pr-4 font-semibold">
+              Course ID
+            </th>
+            <th className="whitespace-nowrap pr-4 font-semibold">
+              Course Name
+            </th>
+            <th className="whitespace-nowrap pr-4 font-semibold">Units</th>
+            <th className="whitespace-nowrap pr-4 font-semibold">Workload</th>
             </tr>
           </thead>
           <tbody className="text-gray-700">
@@ -122,7 +137,7 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
               })}
           </tbody>
         </table>
-      </div>
+      </div>)}
       <div className="text-gray-500 mt-2 text-sm">
         {message === "" ? "" : `*${message}`}
       </div>

--- a/frontend/src/components/ScheduleData.tsx
+++ b/frontend/src/components/ScheduleData.tsx
@@ -72,6 +72,10 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
               {roundTo(aggregatedSelectedData.workload, 2)} hrs/week
               {message === "" ? "" : "*"}
             </span>
+            <span className="ml-4">
+              {scheduledResults.reduce((acc, curr) => acc + parseInt(curr.units), 0)} units
+              {message === "" ? "" : "*"}
+            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ScheduleData.tsx
+++ b/frontend/src/components/ScheduleData.tsx
@@ -74,7 +74,7 @@ const ScheduleData = ({ scheduled }: ScheduleDataProps) => {
           <div className="text-a-600 text-lg">
             Total Workload{" "}
             <span className="ml-4">
-              {scheduledResults.reduce((acc, curr) => acc + parseInt(curr.units), 0)} units,
+              {scheduledResults.reduce((acc, curr) => acc + parseFloat(curr.units), 0)} units,
               {message === "" ? "" : "*"}
             </span>
             <span className="ml-4">


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Made some improvements to the schedules page that I found helpful when trying to build a schedule:
- Show schedules for each course (very helpful to see who is teaching it next semester without clicking into the course)
- Hide the course list summary which takes up a lot of screen real estate
- Add total number of units (so that I don't have to do math)

Closes #140

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tried building schedules in the schedules page

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 18.18.0
- Desktop/Mobile: MacBook Air M2
- OS: Mac Sonoma
- Browser: Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
