### PR TITLE
Fixed issue of having 0 fce responses for certain instructors

### DIFF
--- a/frontend/src/app/fce.ts
+++ b/frontend/src/app/fce.ts
@@ -1,5 +1,5 @@
 import { FCE } from "./types";
-import { compareSessions, roundTo, sessionToShortString } from "./utils";
+import { compareSessions, roundTo, sessionToShortString, responseRateZero } from "./utils";
 
 export const FCE_RATINGS = [
   "Interest in student learning",
@@ -13,7 +13,9 @@ export const FCE_RATINGS = [
   "Overall course rate",
 ];
 
-export const aggregateFCEs = (fces: FCE[]) => {
+export const aggregateFCEs = (rawFces: FCE[]) => {
+  const fces = rawFces.filter((fce) => !responseRateZero(fce))
+
   const fcesCounted = fces.length;
   const semesters = new Set();
   let workload = 0;
@@ -70,12 +72,14 @@ export const filterFCEs = (fces: FCE[], options: AggregateFCEsOptions) => {
     result.push(fce);
   }
 
+  // Filter by courses
   if (options.filters.type === "courses" && options.filters.courses) {
     result = result.filter(({ courseID }) =>
       options.filters.courses.includes(courseID)
     );
   }
 
+  // Filter by instructors
   if (options.filters.type === "instructors" && options.filters.instructors) {
     result = result.filter(({ instructor }) =>
       options.filters.instructors.includes(instructor)

--- a/frontend/src/app/utils.tsx
+++ b/frontend/src/app/utils.tsx
@@ -213,3 +213,9 @@ export function toNameCase(name: string): string {
 export function getUnique<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));
 }
+
+export function responseRateZero(fce: FCE): boolean {
+  // Honestly don't know why responseRate is a string in the first place
+  // Just trying to catch the possible reasonable edge cases
+  return ["0", "0.0", "0.00", "0%", "0.0%", "0.00%"].includes(fce.responseRate);
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Some courses have 0 fce responses which skews the average calculation because each metric defaults to zero.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Tested the fce screen on the following courses:
- [x] 36491: Single fce entry with 0 responses
- [x] 36315 and 51921: Multiple fce entries with a single entry with 0 responses
- [x] 15311: No fce entries

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 18.18.0
- Desktop/Mobile: Macbook Air M2
- OS: Mac Sonoma
- Browser: Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
