### PR TITLE
fix: add chemistry (09XXX) to department filter

### DIFF
--- a/apps/frontend/src/app/constants.ts
+++ b/apps/frontend/src/app/constants.ts
@@ -21,6 +21,7 @@ export const DEPARTMENTS: Department[] = [
   },
   { name: "Center for the Arts in Society", shortName: "CAS", prefix: "64" },
   { name: "Chemical Engineering", shortName: "ChemE", prefix: "06" },
+  { name: "Chemistry", shortName: "Chemistry", prefix: "09" },
   {
     name: "Civil & Environmental Engineering",
     shortName: "CEE",


### PR DESCRIPTION
adds chemistry (09XXX) to the department filter options
it wasn't an option in the filter dropdown since chemistry was missing from the department constants list