### PR TITLE
fix: remove extra (broken) onchange handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 # Next.js
 .next
 out
+.DS_Store

--- a/apps/frontend/src/components/GenedsViewer.tsx
+++ b/apps/frontend/src/components/GenedsViewer.tsx
@@ -42,15 +42,11 @@ const GenedsViewer = () => {
 
   const getGenedTable = () => {
     if (!isSignedIn) {
-      return <></>
+      return <></>;
     }
 
     if (isPending) {
-      return (
-        <div className="py-4 text-center text-gray-500 ">
-          Loading...
-        </div>
-      );
+      return <div className="py-4 text-center text-gray-500 ">Loading...</div>;
     }
 
     if (error) {
@@ -138,7 +134,9 @@ const GenedsViewer = () => {
             setSearchQuery("");
           }}
         >
-          <Combobox.Label className="flex text-gray-700 ">School</Combobox.Label>
+          <Combobox.Label className="flex text-gray-700 ">
+            School
+          </Combobox.Label>
           <Combobox.Button className="relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out border-gray-200 sm:text-sm sm:leading-5 ">
             <span className="flex flex-wrap gap-1">
               <span className="p-0.5 text-gray-500 ">{selectedSchool}</span>
@@ -168,7 +166,9 @@ const GenedsViewer = () => {
           }
           multiple
         >
-          <Combobox.Label className="flex pt-2 text-gray-700 ">Tags</Combobox.Label>
+          <Combobox.Label className="flex pt-2 text-gray-700 ">
+            Tags
+          </Combobox.Label>
 
           <Combobox.Button className="relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out border-gray-200 sm:text-sm sm:leading-5 text-gray-500 ">
             <span className="flex flex-wrap gap-1">
@@ -263,11 +263,10 @@ const GenedsViewer = () => {
             </Combobox.Options>
           </div>
         </Combobox>
-        <Combobox
-          value={searchQuery}
-          onChange={(payload) => setSearchQuery(payload)}
-        >
-          <Combobox.Label className="flex pt-2 text-gray-700">Search</Combobox.Label>
+        <Combobox value={searchQuery}>
+          <Combobox.Label className="flex pt-2 text-gray-700">
+            Search
+          </Combobox.Label>
           <Combobox.Input
             className="relative mt-2 w-full cursor-default rounded border py-1 pl-1 pr-10 text-left transition duration-150 ease-in-out border-gray-200 sm:text-sm sm:leading-5 bg-transparent text-gray-600 placeholder-gray-400 "
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -284,10 +283,10 @@ const GenedsViewer = () => {
           >
             here
           </Link>
-          . Always check with your academic advisor if the course you intend to take still fulfills the requirements you intend it to.
-
-          If there is anything missing, or if you would like a similar list
-          for your school, do fill in the feedback form in the sidebar!
+          . Always check with your academic advisor if the course you intend to
+          take still fulfills the requirements you intend it to. If there is
+          anything missing, or if you would like a similar list for your school,
+          do fill in the feedback form in the sidebar!
         </span>
       </div>
       {!isSignedIn && (

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "axios": "^1.11.0",
         "downshift": "^9.0.10",
         "fuse.js": "^7.1.0",
+        "ical.js": "^2.2.1",
         "jose": "^6.0.13",
         "latest": "^0.2.0",
         "lodash-es": "^4.17.21",
@@ -1915,6 +1916,8 @@
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
     "hyperdyperid": ["hyperdyperid@1.2.0", "", {}, "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="],
+
+    "ical.js": ["ical.js@2.2.1", "", {}, "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg=="],
 
     "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 


### PR DESCRIPTION
closes #270

I really don't know why we have two onChange handlers lol (the outer one sets the search query to `null` instead of `""` lmao)

prettier did some formatting