### PR TITLE
Update Tab Titles for Courses and Instructor Pages

### DIFF
--- a/apps/frontend/src/components/Page.tsx
+++ b/apps/frontend/src/components/Page.tsx
@@ -12,11 +12,19 @@ type Props = {
   sidebar?: React.ReactNode;
   content: React.ReactNode;
   activePage?: string;
+  title?: string;
 };
 
-export const Page = ({ sidebar, content, activePage }: Props) => {
+export const Page = ({ sidebar, content, activePage,title }: Props) => {
   const { isSignedIn, userId } = useAuth();
   const posthog = usePostHog();
+
+  useEffect(() => {
+    // Set the browser tab title
+    if (title) {
+      document.title = title;
+    }
+  }, [title]);
 
   useEffect(() => {
     if (isSignedIn && userId) {

--- a/apps/frontend/src/pages/course/[courseID].tsx
+++ b/apps/frontend/src/pages/course/[courseID].tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
 import CourseDetail from "~/components/CourseDetail";
@@ -10,6 +10,34 @@ import InstructorFilter from "~/components/filters/InstructorFilter";
 const CourseDetailPage: NextPage = () => {
   const router = useRouter();
   const courseID = router.query.courseID as string;
+
+  const [courseTitle, setCourseTitle] = useState("CMU Courses");
+
+  // Dynamic title update logic
+  useEffect(() => {
+    if (!courseID) return;
+
+    async function fetchCourse() {
+      try {
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/course/${courseID}`
+        );
+        const data = await res.json();
+
+        const name = data?.name || "";
+        const number = data?.number || courseID;
+
+        document.title = `${number}: ${name} | CMU Courses`;
+        setCourseTitle(`${number}: ${name}`);
+      } catch (err) {
+        console.error("Failed to fetch course", err);
+      }
+    }
+
+
+    fetchCourse();
+  }, [courseID]);
+
 
   let content = (
     <div className="p-6">

--- a/apps/frontend/src/pages/instructor/[name].tsx
+++ b/apps/frontend/src/pages/instructor/[name].tsx
@@ -17,6 +17,7 @@ const PaddedInstructorDetail = (name: string) => {
 const InstructorPage: NextPage = () => {
   const router = useRouter();
   const name = router.query.name as string;
+  const pageTitle = name ? `Instructor: ${name}` : "Instructors";
 
   return (
     <Page
@@ -27,6 +28,7 @@ const InstructorPage: NextPage = () => {
           <CourseFilter name={name} />
         </>
       }
+      title={pageTitle} // Set dynamic tab title
     />
   );
 };


### PR DESCRIPTION
## Description
This PR updates the browser tab titles for the Courses and Instructor pages to better reflect the content being displayed. Previously, all pages used a generic tab title ("CMU Courses"), which made it harder for users to identify open pages.

## Changes
- Set the tab title dynamically on the Courses page based on the selected course search.
- Set the tab title dynamically on the Instructor page based on the instructor’s name.
- No changes to page functionality or layout were made.

#### Screenshot of the courses tabs open in the browser
<img width="1230" height="54" alt="image" src="https://github.com/user-attachments/assets/a96fc739-4a35-42cd-832d-02472d73323b" />





#### Screenshot of the instructor tab 

<img width="1137" height="57" alt="image" src="https://github.com/user-attachments/assets/98f6d031-8aa7-4913-8742-eb8a3fbe8aaf" />



## Why
- Improves user experience by making it easier to navigate multiple open tabs.
- Provides clear context in the browser tab for the current page.

## Testing
- Verified that selecting a course updates the Courses tab title.
- Verified that viewing an instructor updates the Instructor tab title.
- No errors or layout changes observed.

Closes #245 