### PR TITLE
Added hover tooltip for pre-req, coreq, and crosslisted courses with course name and units

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -49,7 +49,7 @@
     "react-redux": "^9.2.0",
     "react-spinners": "^0.17.0",
     "react-string-replace": "^1.1.1",
-    "react-tooltip": "^5.29.1",
+    "react-tooltip": "^5.30.0",
     "redux-persist": "^6.0.0",
     "use-deep-compare-effect": "^1.8.1",
     "uuid": "^11.1.0"

--- a/apps/frontend/src/components/Buttons.tsx
+++ b/apps/frontend/src/components/Buttons.tsx
@@ -1,4 +1,7 @@
+"use client";
 import React from "react";
+import { useFetchCourseInfo } from "~/app/api/course";
+import { GetTooltip } from "./GetTooltip";
 
 export const SmallButton = ({
   onClick,
@@ -35,12 +38,23 @@ export const FlushedButton = ({
 };
 
 export const CourseIDButton = ({ courseID }: { courseID: string }) => {
+  const { data: course } = useFetchCourseInfo(courseID);
+  const tooltipId = `course-button-${courseID}`;
+
+  const tooltipContent = course
+    ? `${course.name} - ${course.units} units`
+    : "Loading...";
+
   return (
-    <button
-      onClick={() => (window.location.href = `/course/${courseID}`)}
-      className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-20 inline mt-1 mb-1"
-    >
-      {courseID}
-    </button>
+    <>
+      <button
+        onClick={() => (window.location.href = `/course/${courseID}`)}
+        className="font-normal text-center px-2 py-1 text-base bg-gray-50 hover:bg-gray-200 text-gray-900 border border-gray-300 rounded shadow cursor-pointer no-underline min-w-20 inline mt-1 mb-1"
+        data-tooltip-id={tooltipId}
+      >
+        {courseID}
+      </button>
+      <GetTooltip id={tooltipId}>{tooltipContent}</GetTooltip>
+    </>
   );
 };

--- a/apps/frontend/src/components/GetTooltip.tsx
+++ b/apps/frontend/src/components/GetTooltip.tsx
@@ -1,25 +1,26 @@
+"use client";
 import React from "react";
 import { Tooltip } from "react-tooltip";
+import "react-tooltip/dist/react-tooltip.css";
 
 export const GetTooltip = ({
   id,
   children,
 }: {
   id: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }) => {
   return (
     <Tooltip
       id={id}
-      className="max-w-sm z-40 rounded"
-      noArrow={true}
+      className="!bg-gray-50 !text-gray-800 !border !border-gray-300 !rounded !shadow-md max-w-sm z-50 !p-3"
+      noArrow={false}
       opacity={1}
-      style={{ padding: 0 }}
+      place="top"
+      positionStrategy="fixed"
       clickable={true}
     >
-      <div className="flex flex-col bg-gray-50 text-gray-800 -m-1 p-3 rounded border ">
-        <span className="text-wrap text-sm">{children}</span>
-      </div>
+      {children}
     </Tooltip>
   );
 };

--- a/apps/frontend/src/components/Link.tsx
+++ b/apps/frontend/src/components/Link.tsx
@@ -1,5 +1,8 @@
+"use client";
 import { default as NextLink } from "next/link";
 import React from "react";
+import { useFetchCourseInfo } from "~/app/api/course";
+import { GetTooltip } from "./GetTooltip";
 
 const Link = ({
   href,
@@ -11,9 +14,22 @@ const Link = ({
   openInNewTab?: boolean;
   children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLSpanElement>) => {
+  const isCourseLink = href.startsWith("/course/");
+  const courseID = isCourseLink ? href.replace("/course/", "") : undefined;
+  const tooltipId = isCourseLink && courseID ? `link-${courseID}` : undefined;
+
+  const { data: course } = isCourseLink && courseID
+    ? useFetchCourseInfo(courseID)
+    : ({ data: undefined } as any);
+
+  const tooltipContent = course
+    ? `${course.name} - ${course.units} units`
+    : "Loading info...";
+
   const content = (
     <span
       className="cursor-pointer underline decoration-gray-200 hover:no-underline "
+      {...(tooltipId ? { "data-tooltip-id": tooltipId } : {})}
       {...props}
     >
       {children}
@@ -26,6 +42,14 @@ const Link = ({
       </a>
     );
   } else {
+    if (isCourseLink && tooltipId) {
+      return (
+        <>
+          <NextLink href={href}>{content}</NextLink>
+          <GetTooltip id={tooltipId}>{tooltipContent}</GetTooltip>
+        </>
+      );
+    }
     return <NextLink href={href}>{content}</NextLink>;
   }
 };

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmucourses",
@@ -88,7 +89,7 @@
         "react-redux": "^9.2.0",
         "react-spinners": "^0.17.0",
         "react-string-replace": "^1.1.1",
-        "react-tooltip": "^5.29.1",
+        "react-tooltip": "^5.30.0",
         "redux-persist": "^6.0.0",
         "use-deep-compare-effect": "^1.8.1",
         "uuid": "^11.1.0",
@@ -2625,7 +2626,7 @@
 
     "react-string-replace": ["react-string-replace@1.1.1", "", {}, "sha512-26TUbLzLfHQ5jO5N7y3Mx88eeKo0Ml0UjCQuX4BMfOd/JX+enQqlKpL1CZnmjeBRvQE8TR+ds9j1rqx9CxhKHQ=="],
 
-    "react-tooltip": ["react-tooltip@5.29.1", "", { "dependencies": { "@floating-ui/dom": "^1.6.1", "classnames": "^2.3.0" }, "peerDependencies": { "react": ">=16.14.0", "react-dom": ">=16.14.0" } }, "sha512-rmJmEb/p99xWhwmVT7F7riLG08wwKykjHiMGbDPloNJk3tdI73oHsVOwzZ4SRjqMdd5/xwb/4nmz0RcoMfY7Bw=="],
+    "react-tooltip": ["react-tooltip@5.30.0", "", { "dependencies": { "@floating-ui/dom": "^1.6.1", "classnames": "^2.3.0" }, "peerDependencies": { "react": ">=16.14.0", "react-dom": ">=16.14.0" } }, "sha512-Yn8PfbgQ/wmqnL7oBpz1QiDaLKrzZMdSUUdk7nVeGTwzbxCAJiJzR4VSYW+eIO42F1INt57sPUmpgKv0KwJKtg=="],
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 

--- a/packages/db/schema.prisma
+++ b/packages/db/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["fullTextIndex"]
+  binaryTargets   = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
When browsing a course, users can see the prerequisites, corequisites, and crosslisted courses as clickable links that currently show only the course number (e.g., “21-127”, “15-151”). To see the course name and units, users must navigate to the full course page, which disrupts the browsing flow.

This PR adds a hover tooltip to each prereq/coreq/crosslisted link on the course page. The tooltip displays the course name and number of units without leaving the current page.

Example:
If the course is “15-122 - Principles of Imperative Computation (12 units)”, then hovering over the “15-122” link shows:
“Principles of Imperative Computation - 12 units”.

Closes #244.

<img width="811" height="508" alt="Screenshot 2025-12-09 at 07 38 46" src="https://github.com/user-attachments/assets/7380c0bd-5a5d-4e6c-aeca-f52b92d15263" />
